### PR TITLE
Adds ability to use KUBECONFIG envvar

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,11 +33,9 @@ import (
 func main() {
 	var kubeconfig *string
 
-    // TODO(twodarek): Respect KUBECONFIG envvar
-
-    if kubeconfig_envvar := os.Getenv("FOO"); kubeconfig_envvar != "" {
-    	kubeconfig_tokenized := strings.Split(kubeconfig_envvar, ";")
-    	kubeconfig = flag.String("kubeconfig", kubeconfig_tokenized[0], "absolute path to the kubeconfig file")
+    if kubeconfig_envvar := os.Getenv("KUBECONFIG"); kubeconfig_envvar != "" {
+        kubeconfig_tokenized := strings.Split(kubeconfig_envvar, ";")
+        kubeconfig = flag.String("kubeconfig", kubeconfig_tokenized[0], "absolute path to the kubeconfig file")
     } else if home := homeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {


### PR DESCRIPTION
Allows the use of the KUBECONFIG envvar to override the path to the kubeconfig file.
NOTE: if there are multiple kubeconfig files in your $KUBECONFIG, it will only use the first one and not search your full KUBECONFIG path

Fixes #2 