### PR TITLE
Update gitignore to ignore the build binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Ignore the default name for the binary built by `go build .`
+knotready


### PR DESCRIPTION
It was annoying, so I wanted it ignored